### PR TITLE
Adding rule to disallow commits with console.log present

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,6 @@ module.exports = {
     "import/default": 0,
     "memoryleaks": 1,
     "keyword-spacing": 2,
-    "comma-spacing": 2
+    "no-console": ["error", { allow: ["warn", "error"] }]
   }
 };


### PR DESCRIPTION
Adding a rule which means that all commits to repos with eslint configured will not be allowed to contain a console.log. 

This has been tested by adding the rule to index.js in kibi-internal and trying to commit a change which contains a console.log: 

![image](https://user-images.githubusercontent.com/36197976/60822657-d19a5280-a19d-11e9-8c78-c706a794bba1.png)
 