### PR TITLE
Updates package-lock.json with the re-published @elastic/eslint-config-kibana tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       }
     },
     "@elastic/eslint-config-kibana": {
-      "version": "github:sirensolutions/kbn-packages#e8d4cc7cf8f50912ddb212e3236293f0fa0027df",
+      "version": "github:sirensolutions/kbn-packages#3748f5aeaab45c4c2650400be22b46dd265f384f",
       "from": "github:sirensolutions/kbn-packages#elastic-eslint-config-kibana-v7.8.0-gitpkg",
       "requires": {
         "@kbn/eslint-import-resolver-kibana": "github:sirensolutions/kbn-packages#kbn-eslint-import-resolver-kibana-v7.8.0-gitpkg"
@@ -62,9 +62,9 @@
           "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
         },
         "ajv-keywords": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.1.tgz",
-          "integrity": "sha512-KWcq3xN8fDjSB+IMoh2VaXVhRI0BBGxoYp3rx7Pkb6z0cFjYR9Q9l4yZqqals0/zsioCmocC5H6UvsGD4MoIBA=="
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
         },
         "anymatch": {
           "version": "3.1.1",
@@ -92,9 +92,9 @@
           }
         },
         "chokidar": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
-          "integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+          "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
           "optional": true,
           "requires": {
             "anymatch": "~3.1.1",
@@ -223,20 +223,20 @@
           }
         },
         "watchpack": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.2.tgz",
-          "integrity": "sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==",
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
+          "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
           "requires": {
-            "chokidar": "^3.4.0",
+            "chokidar": "^3.4.1",
             "graceful-fs": "^4.1.2",
             "neo-async": "^2.5.0",
             "watchpack-chokidar2": "^2.0.0"
           }
         },
         "webpack": {
-          "version": "4.43.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
-          "integrity": "sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==",
+          "version": "4.44.1",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.1.tgz",
+          "integrity": "sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==",
           "requires": {
             "@webassemblyjs/ast": "1.9.0",
             "@webassemblyjs/helper-module-context": "1.9.0",
@@ -246,7 +246,7 @@
             "ajv": "^6.10.2",
             "ajv-keywords": "^3.4.1",
             "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^4.1.0",
+            "enhanced-resolve": "^4.3.0",
             "eslint-scope": "^4.0.3",
             "json-parse-better-errors": "^1.0.2",
             "loader-runner": "^2.4.0",
@@ -259,7 +259,7 @@
             "schema-utils": "^1.0.0",
             "tapable": "^1.1.3",
             "terser-webpack-plugin": "^1.4.3",
-            "watchpack": "^1.6.1",
+            "watchpack": "^1.7.4",
             "webpack-sources": "^1.4.1"
           },
           "dependencies": {
@@ -4479,9 +4479,9 @@
       },
       "dependencies": {
         "ajv-keywords": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.1.tgz",
-          "integrity": "sha512-KWcq3xN8fDjSB+IMoh2VaXVhRI0BBGxoYp3rx7Pkb6z0cFjYR9Q9l4yZqqals0/zsioCmocC5H6UvsGD4MoIBA=="
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
         }
       }
     },
@@ -4491,9 +4491,9 @@
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "serialize-javascript": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-      "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
       "requires": {
         "randombytes": "^2.1.0"
       }
@@ -4969,15 +4969,15 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz",
-      "integrity": "sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+      "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^3.1.0",
+        "serialize-javascript": "^4.0.0",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",


### PR DESCRIPTION
[INVE-12214]
We may want to re-publish tag `0.4` if it's not being used by anybody other than kibi-internal yet.

[INVE-12214]: https://sirensolutions.atlassian.net/browse/INVE-12214